### PR TITLE
Use new syntax for get request in spec file

### DIFF
--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CategoriesController, type: :controller do
     it "returns http success" do
       category = Category.create(name: 'category')
 
-      get :show, id: category.id
+      get :show, params: { id: category.id }
 
       expect(response).to have_http_status(:success)
     end


### PR DESCRIPTION
n Rails 5+, the controller test API changed. In older versions (like 4.1), you could write:

`get :show, id: category.id`

…but in Rails 5 and later (including Rails 7.1), you must wrap all route parameters in a params: hash:

`get :show, params: { id: category.id }`

Without the params: key, Rails doesn’t know that id is supposed to be part of the request parameters, which is why your test fails with:

`ArgumentError: unknown keyword: :id`
